### PR TITLE
進捗報告

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ target/
 *.swp
 
 progress_*.png
+result_tle.png
 
 #
 # https://github.com/github/gitignore/blob/master/Global/JetBrains.gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ target/
 **/*.rs.bk
 *.swp
 
+progress_*.png
+
 #
 # https://github.com/github/gitignore/blob/master/Global/JetBrains.gitignore
 #

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -17,5 +17,5 @@ pub const GAMMA_FACTOR: f64 = 2.2;
 
 // レイトレ合宿5のレギュレーション用
 // https://sites.google.com/site/raytracingcamp5/
-pub const REPORT_INTERVAL_SEC: f64 = 3.0;// 30秒ごとに途中結果を出力
-pub const TIME_LIMIT_SEC: f64 = 10.0;//(4 * 60 + 33) as f64;// 4分33秒以内に自動で終了
+pub const REPORT_INTERVAL_SEC: f64 = 30.0;// 30秒ごとに途中結果を出力
+pub const TIME_LIMIT_SEC: f64 = (4 * 60 + 33) as f64;// 4分33秒以内に自動で終了

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -14,3 +14,8 @@ pub const PATHTRACING_SAMPLING: u32 = 30;
 pub const SUPERSAMPLING: u32 = 2;
 
 pub const GAMMA_FACTOR: f64 = 2.2;
+
+// レイトレ合宿5のレギュレーション用
+// https://sites.google.com/site/raytracingcamp5/
+pub const REPORT_INTERVAL_SEC: i64 = 10;// 30秒ごとに途中結果を出力
+pub const TIME_LIMIT_SEC: i64 = 4 * 60 + 33;// 4分33秒以内に自動で終了

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -17,5 +17,5 @@ pub const GAMMA_FACTOR: f64 = 2.2;
 
 // レイトレ合宿5のレギュレーション用
 // https://sites.google.com/site/raytracingcamp5/
-pub const REPORT_INTERVAL_SEC: i64 = 10;// 30秒ごとに途中結果を出力
-pub const TIME_LIMIT_SEC: i64 = 4 * 60 + 33;// 4分33秒以内に自動で終了
+pub const REPORT_INTERVAL_SEC: i64 = 3;// 30秒ごとに途中結果を出力
+pub const TIME_LIMIT_SEC: f64 = 10.0;//(4 * 60 + 33) as f64;// 4分33秒以内に自動で終了

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -17,5 +17,5 @@ pub const GAMMA_FACTOR: f64 = 2.2;
 
 // レイトレ合宿5のレギュレーション用
 // https://sites.google.com/site/raytracingcamp5/
-pub const REPORT_INTERVAL_SEC: i64 = 3;// 30秒ごとに途中結果を出力
+pub const REPORT_INTERVAL_SEC: f64 = 3.0;// 30秒ごとに途中結果を出力
 pub const TIME_LIMIT_SEC: f64 = 10.0;//(4 * 60 + 33) as f64;// 4分33秒以内に自動で終了

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,8 +124,8 @@ fn render() {
         ),
     };
 
-    //let renderer = DebugRenderer{};
-    let renderer = PathTracingRenderer {};
+    //let mut renderer = DebugRenderer{};
+    let mut renderer = PathTracingRenderer::new();
     renderer.render(&scene, &camera, &mut imgbuf);
 
     let ref mut fout = File::create(&Path::new("test.png")).unwrap();

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -209,7 +209,8 @@ impl Renderer for PathTracingRenderer {
 
         println!("rendering: {:.2} % {:.3} sec.", progress, passed_time);
 
-        if (now - self.last_report_image).num_seconds() > consts::REPORT_INTERVAL_SEC {
+        let interval_time = (now - self.last_report_image).num_milliseconds() as f64 * 0.001;
+        if interval_time >= consts::REPORT_INTERVAL_SEC {
             // save progress image
             let path = format!("progress_{:>03}.png", self.report_image_counter);
             println!("output progress image: {}", path);

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -205,7 +205,9 @@ impl Renderer for PathTracingRenderer {
 
         let now = time::now();
         if (now - self.last_report_image).num_seconds() > consts::REPORT_INTERVAL_SEC {
-            let ref mut fout = File::create(&Path::new(&format!("progress_{:>03}.png", self.report_image_counter))).unwrap();
+            let path = format!("progress_{:>03}.png", self.report_image_counter);
+            println!("output progress image: {}", path);
+            let ref mut fout = File::create(&Path::new(&path)).unwrap();
             let _ = image::ImageRgb8(imgbuf.clone()).save(fout, image::PNG);
             self.report_image_counter += 1;
             self.last_report_image = now;

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -53,6 +53,11 @@ pub trait Renderer: Sync {
 
     fn report_progress(&mut self, y: u32, height: f64, imgbuf: &ImageBuffer<Rgb<u8>, Vec<u8>>);
 
+    fn save_progress_image(path: &str, imgbuf: &ImageBuffer<Rgb<u8>, Vec<u8>>) {
+        let ref mut fout = File::create(&Path::new(path)).unwrap();
+        let _ = image::ImageRgb8(imgbuf.clone()).save(fout, image::PNG);
+    }
+
     fn supersampling(&self, scene: &Scene, camera: &Camera, frag_coord: &Vector2, resolution: &Vector2) -> Color {
         let mut accumulation = Color::zero();
 
@@ -214,15 +219,16 @@ impl Renderer for PathTracingRenderer {
             // save progress image
             let path = format!("progress_{:>03}.png", self.report_image_counter);
             println!("output progress image: {}", path);
-            let ref mut fout = File::create(&Path::new(&path)).unwrap();
-            let _ = image::ImageRgb8(imgbuf.clone()).save(fout, image::PNG);
+            PathTracingRenderer::save_progress_image(&path, imgbuf);
             self.report_image_counter += 1;
             self.last_report_image = now;
         }
 
         if passed_time > consts::TIME_LIMIT_SEC {
             // die when time limit exceeded
-            println!("time limit exceeded: {:.3} sec.", passed_time);
+            let path = "result_tle.png";
+            println!("time limit exceeded: {:.3} sec. {}", passed_time, path);
+            PathTracingRenderer::save_progress_image(path, imgbuf);
             process::exit(1);
         }
     }

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -3,12 +3,13 @@ extern crate rand;
 extern crate rayon;
 extern crate time;
 
+use std::fs::File;
+use std::path::Path;
+use std::process;
+use time::Tm;
 use image::{ImageBuffer, Rgb};
 use self::rand::thread_rng;
 use self::rayon::prelude::*;
-use std::fs::File;
-use std::path::Path;
-use time::Tm;
 
 use consts;
 use vector::{Vector3, Vector2};
@@ -209,12 +210,19 @@ impl Renderer for PathTracingRenderer {
         println!("rendering: {:.2} % {:.3} sec.", progress, passed_time);
 
         if (now - self.last_report_image).num_seconds() > consts::REPORT_INTERVAL_SEC {
+            // save progress image
             let path = format!("progress_{:>03}.png", self.report_image_counter);
             println!("output progress image: {}", path);
             let ref mut fout = File::create(&Path::new(&path)).unwrap();
             let _ = image::ImageRgb8(imgbuf.clone()).save(fout, image::PNG);
             self.report_image_counter += 1;
             self.last_report_image = now;
+        }
+
+        if passed_time > consts::TIME_LIMIT_SEC {
+            // die when time limit exceeded
+            println!("time limit exceeded: {:.3} sec.", passed_time);
+            process::exit(1);
         }
     }
 }

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -201,9 +201,13 @@ impl Renderer for PathTracingRenderer {
     }
 
     fn report_progress(&mut self, y: u32, height: f64, imgbuf: &ImageBuffer<Rgb<u8>, Vec<u8>>) {
-        println!("rendering: {}%", (y as f64 + 1.0) / height * 100.0);
+        let progress = (y as f64 + 1.0) / height * 100.0;
 
         let now = time::now();
+        let passed_time = (now - self.begin).num_milliseconds() as f64 * 0.001;
+
+        println!("rendering: {:.2} % {:.3} sec.", progress, passed_time);
+
         if (now - self.last_report_image).num_seconds() > consts::REPORT_INTERVAL_SEC {
             let path = format!("progress_{:>03}.png", self.report_image_counter);
             println!("output progress image: {}", path);


### PR DESCRIPTION
[レイトレ合宿5](https://sites.google.com/site/raytracingcamp5/)のレギュレーションのための機能。

- おおよそ30秒毎に、レンダリングの途中経過をbmpかpngで連番(000.png, 001.png, ...) で出力してください。
   - 30秒毎に `progress_xxx.png` を連番で出力
- 4分33秒以内に自動で終了してください。
   - 4分33秒経過後に、 `result_tle.png` を出力後、exit 1